### PR TITLE
Add support for rfc 2324

### DIFF
--- a/statuscodes/statuscodes.go
+++ b/statuscodes/statuscodes.go
@@ -15,3 +15,4 @@ var NotFound = HTTPStatus{404, "not found"}
 var Ok = HTTPStatus{200, "OK"}
 var MethodNotAllowed = HTTPStatus{405, "method not allowed"}
 var ServerError = HTTPStatus{500, "internal server error"}
+var Teapot = HTTPStatus{418, "I'm a teapot"}


### PR DESCRIPTION
This PR adds support for the Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0) as outlined in [RFC2324](https://tools.ietf.org/html/rfc2324#section-2.3.2)

> Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot". The resulting entity body MAY be short and stout.